### PR TITLE
【Hubs空間の調整】招待ボタンの非表示

### DIFF
--- a/src/react-components/room/InvitePopover.js
+++ b/src/react-components/room/InvitePopover.js
@@ -2,13 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "./InvitePopover.scss";
 import { CopyableTextInputField } from "../input/CopyableTextInputField";
-import { Popover } from "../popover/Popover";
-import { ToolbarButton } from "../input/ToolbarButton";
-import { ReactComponent as InviteIcon } from "../icons/Invite.svg";
+// import { Popover } from "../popover/Popover";
+// import { ToolbarButton } from "../input/ToolbarButton";
+// import { ReactComponent as InviteIcon } from "../icons/Invite.svg";
 import { Column } from "../layout/Column";
 import { InviteLinkInputField } from "./InviteLinkInputField";
 import { FormattedMessage, defineMessage, useIntl } from "react-intl";
-import { ToolTip } from "@mozilla/lilypad-ui";
+// import { ToolTip } from "@mozilla/lilypad-ui";
 
 function InvitePopoverContent({ url, embed, inviteRequired, fetchingInvite, inviteUrl, revokeInvite }) {
   return (
@@ -46,15 +46,15 @@ InvitePopoverContent.propTypes = {
   revokeInvite: PropTypes.func
 };
 
-const inviteTooltipDescription = defineMessage({
-  id: "invite-tooltip.description",
-  defaultMessage: "Copy room link to invite others to the room"
-});
+// const inviteTooltipDescription = defineMessage({
+//   id: "invite-tooltip.description",
+//   defaultMessage: "Copy room link to invite others to the room"
+// });
 
-const invitePopoverTitle = defineMessage({
-  id: "invite-popover.title",
-  defaultMessage: "Invite"
-});
+// const invitePopoverTitle = defineMessage({
+//   id: "invite-popover.title",
+//   defaultMessage: "Invite"
+// });
 
 export function InvitePopoverButton({
   url,
@@ -67,42 +67,43 @@ export function InvitePopoverButton({
   revokeInvite,
   ...rest
 }) {
-  const intl = useIntl();
-  const title = intl.formatMessage(invitePopoverTitle);
-  const description = intl.formatMessage(inviteTooltipDescription);
+  /*今回招待ボタンは使用しないため非表示 */
+  // const intl = useIntl();
+  // const title = intl.formatMessage(invitePopoverTitle);
+  // const description = intl.formatMessage(inviteTooltipDescription);
 
-  return (
-    <Popover
-      title={title}
-      content={() => (
-        <InvitePopoverContent
-          url={url}
-          embed={embed}
-          inviteRequired={inviteRequired}
-          fetchingInvite={fetchingInvite}
-          inviteUrl={inviteUrl}
-          revokeInvite={revokeInvite}
-        />
-      )}
-      placement="top-start"
-      offsetDistance={28}
-      initiallyVisible={initiallyVisible}
-      popoverApiRef={popoverApiRef}
-    >
-      {({ togglePopover, popoverVisible, triggerRef }) => (
-        <ToolTip description={description}>
-          <ToolbarButton
-            ref={triggerRef}
-            icon={<InviteIcon />}
-            selected={popoverVisible}
-            onClick={togglePopover}
-            label={title}
-            {...rest}
-          />
-        </ToolTip>
-      )}
-    </Popover>
-  );
+  // return (
+  //   <Popover
+  //     title={title}
+  //     content={() => (
+  //       <InvitePopoverContent
+  //         url={url}
+  //         embed={embed}
+  //         inviteRequired={inviteRequired}
+  //         fetchingInvite={fetchingInvite}
+  //         inviteUrl={inviteUrl}
+  //         revokeInvite={revokeInvite}
+  //       />
+  //     )}
+  //     placement="top-start"
+  //     offsetDistance={28}
+  //     initiallyVisible={initiallyVisible}
+  //     popoverApiRef={popoverApiRef}
+  //   >
+  //     {({ togglePopover, popoverVisible, triggerRef }) => (
+  //       <ToolTip description={description}>
+  //         <ToolbarButton
+  //           ref={triggerRef}
+  //           icon={<InviteIcon />}
+  //           selected={popoverVisible}
+  //           onClick={togglePopover}
+  //           label={title}
+  //           {...rest}
+  //         />
+  //       </ToolTip>
+  //     )}
+  //   </Popover>
+  // );
 }
 
 InvitePopoverButton.propTypes = {

--- a/src/react-components/room/RoomSettingsSidebar.js
+++ b/src/react-components/room/RoomSettingsSidebar.js
@@ -120,7 +120,7 @@ export function RoomSettingsSidebar({
             error={errors?.entry_mode?.message}
             {...register("entry_mode")}
           />
-          <RadioInputOption
+          {/* <RadioInputOption
             value="invite"
             label={<FormattedMessage id="room-settings-sidebar.access-invite" defaultMessage="Invite only" />}
             description={
@@ -131,7 +131,7 @@ export function RoomSettingsSidebar({
             }
             error={errors?.entry_mode?.message}
             {...register("entry_mode")}
-          />
+          /> */}
         </RadioInputField>
         {entryMode === "invite" && (
           <InviteLinkInputField fetchingInvite={fetchingInvite} inviteUrl={inviteUrl} onRevokeInvite={onRevokeInvite} />

--- a/src/react-components/room/Tooltip.js
+++ b/src/react-components/room/Tooltip.js
@@ -58,10 +58,10 @@ const onboardingMessages = defineMessages({
     id: "tips.desktop.turning2",
     defaultMessage: "Use {left} or {right} or click and drag to look around"
   },
-  "tips.desktop.invite": {
-    id: "tips.desktop.invite2",
-    defaultMessage: "<p>Use the {invite} button to share</p><p2>this room</p2>"
-  },
+  // "tips.desktop.invite": {
+  //   id: "tips.desktop.invite2",
+  //   defaultMessage: "<p>Use the {invite} button to share</p><p2>this room</p2>"
+  // },
   "tips.end": {
     id: "tips.end",
     defaultMessage: "Tutorial completed! Have fun exploring"
@@ -86,10 +86,10 @@ const onboardingMessages = defineMessages({
     id: "tips.text.more",
     defaultMessage: "More"
   },
-  "tips.text.invite": {
-    id: "tips.text.invite",
-    defaultMessage: "Invite"
-  }
+  // "tips.text.invite": {
+  //   id: "tips.text.invite",
+  //   defaultMessage: ""
+  // }
 });
 
 function isStep(step, item) {
@@ -97,7 +97,7 @@ function isStep(step, item) {
 }
 
 function maxSteps(step) {
-  return isStep(step, "desktop") ? 3 : 2;
+  return isStep(step, "desktop") ? 2 : 1;
 }
 
 function Key({ children }) {
@@ -269,24 +269,26 @@ function onboardingSteps({ intl, step }) {
         }
       };
     case "tips.desktop.invite":
-      return {
-        control: {
-          type: Step,
-          params: {
-            invite: (
-              <InlineButton icon={<InviteIcon />} text={intl.formatMessage(onboardingMessages["tips.text.invite"])} />
-            ),
-            p: chunks => <p style={{ width: "100%" }}>{chunks}</p>,
-            p2: chunks => <p style={{ width: "100%" }}>{chunks}</p>
-          }
-        },
-        navigationBar: {
-          type: StepNavigationBar,
-          params: {
-            currentStep: 2
-          }
-        }
-      };
+      return onboardingSteps({ intl, step: "tips.desktop.end" });
+      // return {
+      //   control: {
+      //     type: Step,
+      //     // params: {
+      //     //   invite: (
+      //     //     <InlineButton icon={<InviteIcon />} text={intl.formatMessage(onboardingMessages["tips.text.invite"])} />
+      //     //   ),
+      //     //   p: chunks => <p style={{ width: "100%" }}>{chunks}</p>,
+      //     //   p2: chunks => <p style={{ width: "100%" }}>{chunks}</p>
+      //     // }
+      //   },
+      //   navigationBar: {
+      //     type: StepNavigationBar,
+      //     params: {
+      //       currentStep: 2
+      //     }
+      //   }
+      // };
+
     case "tips.desktop.menu":
       return {
         control: {

--- a/src/react-components/styles/theme.scss
+++ b/src/react-components/styles/theme.scss
@@ -64,7 +64,7 @@ $orange: #ff8500;
 $orange-hover: #ff911a;
 $orange-pressed: #e67800;
 
-$green: green;
+$green: #8cdf2f;
 $green-hover: #8cdf2f;
 $green-pressed: #72be1d;
 

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -332,9 +332,10 @@ class UIRoot extends Component {
         this.setState({ watching: false });
       }
     });
-    this.props.scene.addEventListener("action_toggle_ui", () =>
-      this.setState({ hide: !this.state.hide, hideUITip: false })
-    );
+    this.props.scene.addEventListener("action_toggle_ui", () => {
+      this.setState({ hide: !this.state.hide, hideUITip: false });
+    });
+
     this.props.scene.addEventListener("action_toggle_record", () => {
       const cursor = document.querySelector("#right-cursor");
       if (this.state.isRecordingMode) {
@@ -1216,13 +1217,13 @@ class UIRoot extends Component {
             icon: HomeIcon,
             onClick: () => this.setSidebar("room-info")
           },
-          (this.props.breakpoint === "sm" || this.props.breakpoint === "md") &&
-            (this.props.hub.entry_mode !== "invite" || this.props.hubChannel.can("update_hub")) && {
-              id: "invite",
-              label: <FormattedMessage id="more-menu.invite" defaultMessage="Invite" />,
-              icon: InviteIcon,
-              onClick: () => this.props.scene.emit("action_invite")
-            },
+          // (this.props.breakpoint === "sm" || this.props.breakpoint === "md") &&
+          //   (this.props.hub.entry_mode !== "invite" || this.props.hubChannel.can("update_hub")) && {
+          //     id: "invite",
+          //     label: <FormattedMessage id="more-menu.invite" defaultMessage="Invite" />,
+          //     icon: InviteIcon,
+          //     onClick: () => this.props.scene.emit("action_invite")
+          //   },
           this.isFavorited()
             ? {
                 id: "unfavorite-room",

--- a/src/systems/tips.js
+++ b/src/systems/tips.js
@@ -19,7 +19,7 @@ const FINISH = 2;
 const LOCAL_STORAGE_KEY = "__hubs_finished_tips";
 
 const TIPS = {
-  desktop: ["welcome", "locomotion", "turning", "invite", "end", "menu"],
+  desktop: ["welcome", "locomotion", "turning", "end", "menu"],
   mobile: ["welcome", "locomotion", "turning", "end", "menu"],
   standalone: []
 };


### PR DESCRIPTION
元々依頼いただいていたツールバー下部の招待ボタンに加えて3点招待周り非表示にしました。

  "invite-popover.title": "招待", →下部ツールバー(対応済み)
  "more-menu.invite": "招待", →メニューの招待リンク(対応済み)
  "tips.text.invite": "招待", →チュートリアルstep3(対応済み)
  "room-settings-sidebar.access-invite": "招待者のみ", →ルーム編集メニュー(対応済み)

![スクリーンショット 2024-04-18 12 05 12](https://github.com/icogiso/dxe_3d_hubs/assets/165109292/bb8cb9d1-ac8d-4cac-b20b-68a6cca6f143)
![スクリーンショット 2024-04-19 17 01 34](https://github.com/icogiso/dxe_3d_hubs/assets/165109292/1e4af496-a590-4757-932d-faaa5f032d23)

