### PR TITLE
Admin判定の検証＋ログインページのボタンをコメントアウト

### DIFF
--- a/src/react-components/room/RoomEntryModal.js
+++ b/src/react-components/room/RoomEntryModal.js
@@ -25,6 +25,7 @@ export function RoomEntryModal({
   onSpectate,
   showRoomSettings,
   onRoomSettings,
+  isAdmin,
   ...rest
 }) {
   const breakpoint = useCssBreakpoints();
@@ -47,23 +48,26 @@ export function RoomEntryModal({
               </span>
             </Button>
           )}
-          {showEnterOnDevice && (
+          {/* {showEnterOnDevice && (
             <Button preset="accent5" onClick={onEnterOnDevice}>
               <VRIcon />
               <span>
                 <FormattedMessage id="room-entry-modal.enter-on-device-button" defaultMessage="Enter On Device" />
               </span>
             </Button>
-          )}
-          {showSpectate && (
+          )} */}
+              <div>
+              {isAdmin ? <p>Admin</p> : <p>Not Admin</p>}
+            </div>
+          {/* {showSpectate && (
             <Button preset="accent2" onClick={onSpectate}>
               <ShowIcon />
               <span>
                 <FormattedMessage id="room-entry-modal.spectate-button" defaultMessage="Spectate" />
               </span>
             </Button>
-          )}
-          {showRoomSettings && breakpoint !== "sm" && (
+          )} */}
+          {/* {showRoomSettings && breakpoint !== "sm" && (
             <>
               <hr className={styleUtils.showLg} />
               <Button preset="transparent" className={styleUtils.showLg} onClick={onRoomSettings}>
@@ -73,7 +77,7 @@ export function RoomEntryModal({
                 </span>
               </Button>
             </>
-          )}
+          )} */}
         </Column>
       </Column>
     </Modal>

--- a/src/react-components/ui-root.js
+++ b/src/react-components/ui-root.js
@@ -837,6 +837,7 @@ class UIRoot extends Component {
     return (
       <>
         <RoomEntryModal
+          isAdmin={this.state.isAdmin}
           roomName={this.props.hub.name}
           showJoinRoom={!this.state.waitingOnAudio && !this.props.entryDisallowed}
           onJoinRoom={() => {


### PR DESCRIPTION
# 作業内容
「デバイスで入室」、「観客モードで入室」、「ルームの設定」のボタンを削除（「デバイスで入室」は協議の上VRモードが必要であれば残す）

# 関連チケット
https://oc-dmm.backlog.com/view/PFDEV-1229

# その他
Adminかどうかの判定は現状ローカルのフロントでは確認・変更できないので一度stgへ上げて検証したいです。
ログインしているしていない判定は確認できていて、Adminも同様の処理でいけるとは思ってます。
一旦「デバイスで入室」も消します。(協議の上必要があればコメントアウト解除します)