### PR TITLE
未ログイン時に共有ボタンが表示されるのを再修正

### DIFF
--- a/src/react-components/room/SharePopoverContainer.js
+++ b/src/react-components/room/SharePopoverContainer.js
@@ -136,7 +136,8 @@ export function SharePopoverContainer({ scene, hubChannel, showNonHistoriedDialo
       icon: UploadIcon,
       color: "accent5",
       label: <FormattedMessage id="place-popover.item-type.upload" defaultMessage="Upload" />,
-      onSelect: () => showNonHistoriedDialog(ObjectUrlModalContainer, { scene })
+      onSelect: () => showNonHistoriedDialog(ObjectUrlModalContainer, { scene }),
+      active: sharingSource === MediaDevices.SCREEN
     },
     canShareCamera && {
       id: "camera",


### PR DESCRIPTION
資料共有ですが、画面共有と同じ条件で出すようにしました。
ローカルでは確認できないのでstg上で検証します。